### PR TITLE
implement (<**>) using (=<<) and (<$>)

### DIFF
--- a/src/Course/Monad.hs
+++ b/src/Course/Monad.hs
@@ -112,9 +112,7 @@ instance Monad ((->) t) where
   -> f a
   -> f b
 f <**> a =
-  f >>= \f' ->
-  a >>= \a' ->
-  pure (f' a')
+  (<$> a) =<< f
 
 infixl 4 <**>
 


### PR DESCRIPTION
This version better reflects the documentation on L78:
```-- | Witness that all things with (=<<) and (<$>) also have (<*>).```

I was stumped by this exercise while going through https://github.com/system-f/fp-course
and came here looking for a solution. Eventually I figured out this formulation, which I think
is more fitting. It's actually not immediately obvious to me (a beginner) that `(>>=)` is
defined here.